### PR TITLE
Added SVN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ with interesting attributes. For example, find the slowest specs, or the
 spec which issues the most queries.
 
 Collected attributes include:
-- git commit SHA and date
+- git commit SHA (or SVN revision) and date
 - example file, line number and description
 - example status (i.e. passed or failed)
 - example time

--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -4,8 +4,8 @@ module RspecProfiling
   module Collectors
     class CSV
       HEADERS = %w{
-        commit_sha
-        commit_date
+        commit
+        date
         file
         line_number
         description

--- a/lib/rspec_profiling/collectors/database.rb
+++ b/lib/rspec_profiling/collectors/database.rb
@@ -24,8 +24,8 @@ module RspecProfiling
         return if prepared?
 
         connection.create_table(table) do |t|
-          t.string    :commit_sha
-          t.datetime  :commit_date
+          t.string    :commit
+          t.datetime  :date
           t.text      :file
           t.integer   :line_number
           t.text      :description

--- a/lib/rspec_profiling/current_commit.rb
+++ b/lib/rspec_profiling/current_commit.rb
@@ -4,12 +4,25 @@ module RspecProfiling
   module CurrentCommit
     extend self
 
+    def git?
+      `git rev-parse 2>&1`
+      $?.success?
+    end
+
     def sha
-      `git rev-parse HEAD`
+      if git?
+        `git rev-parse HEAD`
+      else
+        `svn info -r 'HEAD' | grep "Revision" | cut -f2 -d' '`
+      end
     end
 
     def time
-      Time.parse `git show -s --format=%ci #{sha}`
+      if git?
+        Time.parse `git show -s --format=%ci #{sha}`
+      else
+        Time.parse `svn info -r 'HEAD' | grep "Last Changed Date" | cut -f4,5,6 -d' '`
+      end
     end
   end
 end

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -19,8 +19,8 @@ module RspecProfiling
 
     def example_finished(*args)
       collector.insert({
-        commit_sha:    CurrentCommit.sha,
-        commit_date:   CurrentCommit.time,
+        commit:        CurrentCommit.sha,
+        date:          CurrentCommit.time,
         file:          @current_example.file,
         line_number:   @current_example.line_number,
         description:   @current_example.description,

--- a/spec/collectors/database_spec.rb
+++ b/spec/collectors/database_spec.rb
@@ -13,8 +13,8 @@ module RspecProfiling
 
         before do
           collector.insert({
-            commit_sha: "ABC123",
-            commit_date: "Thu Dec 18 12:00:00 2012",
+            commit: "ABC123",
+            date: "Thu Dec 18 12:00:00 2012",
             file: "/some/file.rb",
             line_number: 10,
             description: "Some spec",
@@ -32,7 +32,7 @@ module RspecProfiling
         end
 
         it "records the commit SHA" do
-          expect(result.commit_sha).to eq "ABC123"
+          expect(result.commit).to eq "ABC123"
         end
 
         it "records the commit date" do

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -23,7 +23,7 @@ module RspecProfiling
       let(:result)    { collector.results.first }
       let(:commit) do
         double({
-          sha: "abc123",
+          commit: "abc123",
           time: Time.new(2012, 12, 12)
         })
       end


### PR DESCRIPTION
This PR simply makes this usable for SVN as well as Git projects. Obviously for projects using both Git and SVN (via `git svn` or something similar), this could get complicated, but besides that it makes working with either version control system simpler!
