### PR TITLE
Track the current branch when available

### DIFF
--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -4,6 +4,7 @@ module RspecProfiling
   module Collectors
     class CSV
       HEADERS = %w{
+        branch
         commit
         date
         file

--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -25,6 +25,7 @@ module RspecProfiling
         return if prepared?
 
         connection.create_table(table) do |t|
+          t.string    :branch
           t.string    :commit
           t.datetime  :date
           t.text      :file

--- a/lib/rspec_profiling/collectors/sql.rb
+++ b/lib/rspec_profiling/collectors/sql.rb
@@ -25,6 +25,7 @@ module RspecProfiling
         return if prepared?
 
         connection.create_table(table) do |t|
+          t.string    :branch
           t.string    :commit
           t.datetime  :date
           t.text      :file

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -27,6 +27,7 @@ module RspecProfiling
 
     def example_finished(*args)
       collector.insert({
+        branch:        vcs.branch,
         commit:        vcs.sha,
         date:          vcs.time,
         file:          @current_example.file,

--- a/lib/rspec_profiling/vcs/git.rb
+++ b/lib/rspec_profiling/vcs/git.rb
@@ -3,6 +3,10 @@ require 'time'
 module RspecProfiling
   module VCS
     class Git
+      def branch
+        `git rev-parse --abbrev-ref HEAD`
+      end
+
       def sha
         `git rev-parse HEAD`
       end

--- a/lib/rspec_profiling/vcs/git_svn.rb
+++ b/lib/rspec_profiling/vcs/git_svn.rb
@@ -9,6 +9,10 @@ module RspecProfiling
         RspecProfiling::VCS::Svn unless $CHILD_STATUS.success?
       end
 
+      def branch
+        nil
+      end
+
       def sha
         if version_control.nil?
           `git svn info | grep "Revision" | cut -f2 -d' '`

--- a/lib/rspec_profiling/vcs/svn.rb
+++ b/lib/rspec_profiling/vcs/svn.rb
@@ -3,6 +3,10 @@ require 'time'
 module RspecProfiling
   module VCS
     class Svn
+      def branch
+        nil
+      end
+
       def sha
         `svn info -r 'HEAD' | grep "Revision" | cut -f2 -d' '`
       end

--- a/spec/collectors/psql_spec.rb
+++ b/spec/collectors/psql_spec.rb
@@ -13,6 +13,7 @@ module RspecProfiling
 
         before do
           collector.insert({
+            branch: "master",
             commit: "ABC123",
             date: "Thu Dec 18 12:00:00 2012",
             file: "/some/file.rb",
@@ -30,6 +31,10 @@ module RspecProfiling
 
         it "records a single result" do
           expect(collector.results.count).to eq 1
+        end
+
+        it "records the branch name" do
+          expect(result.branch).to eq "master"
         end
 
         it "records the commit SHA" do

--- a/spec/collectors/sql_spec.rb
+++ b/spec/collectors/sql_spec.rb
@@ -13,6 +13,7 @@ module RspecProfiling
 
         before do
           collector.insert({
+            branch: "master",
             commit: "ABC123",
             date: "Thu Dec 18 12:00:00 2012",
             file: "/some/file.rb",
@@ -30,6 +31,10 @@ module RspecProfiling
 
         it "records a single result" do
           expect(collector.results.count).to eq 1
+        end
+
+        it "records the branch name" do
+          expect(result.branch).to eq "master"
         end
 
         it "records the commit SHA" do

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -19,14 +19,9 @@ module RspecProfiling
 
     describe "#run_example" do
       let(:collector) { CollectorDouble.new }
-      let(:run)       { described_class.new(collector) }
+      let(:vcs) { VcsDouble.new }
+      let(:run)       { described_class.new(collector, vcs) }
       let(:result)    { collector.results.first }
-      let(:commit) do
-        double({
-          commit: "abc123",
-          time: Time.new(2012, 12, 12)
-        })
-      end
       let(:example) do
         ExampleDouble.new({
           file_path: "/something_spec.rb",
@@ -45,13 +40,20 @@ module RspecProfiling
       end
 
       before do
-        stub_const("RspecProfiling::CurrentCommit", commit)
         stub_const("ActiveSupport::Notifications", Notifications.new)
         simulate_test_suite_run
       end
 
       it "collects a single example" do
         expect(collector.count).to eq 1
+      end
+
+      it "records the branch name" do
+        expect(result.branch).to eq "master"
+      end
+
+      it "records the commit SHA" do
+        expect(result.commit).to eq "abc123"
       end
 
       it "counts two queries" do
@@ -100,6 +102,20 @@ module RspecProfiling
 
       def count
         results.count
+      end
+    end
+
+    class VcsDouble
+      def branch
+        "master"
+      end
+
+      def sha
+        "abc123"
+      end
+
+      def time
+        0.1
       end
     end
 

--- a/spec/vcs/git_spec.rb
+++ b/spec/vcs/git_spec.rb
@@ -1,0 +1,27 @@
+require "rspec_profiling/vcs/git"
+
+module RspecProfiling
+  describe VCS::Git do
+    describe "#branch" do
+      it "calls Git to get the current branch" do
+        expect(subject).to receive(:`).with("git rev-parse --abbrev-ref HEAD").and_return("master")
+        expect(subject.branch).to eq "master"
+      end
+    end
+
+    describe "#sha" do
+      it "calls Git to get the current commit's SHA" do
+        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123")
+        expect(subject.sha).to eq "abc123"
+      end
+    end
+
+    describe "#time" do
+      it "calls Git to get the current commit's datetime" do
+        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123")
+        expect(subject).to receive(:`).with("git show -s --format=%ci abc123").and_return("2017-01-31")
+        expect(subject.time).to eq Time.parse("2017-01-31")
+      end
+    end
+  end
+end

--- a/spec/vcs/svn_spec.rb
+++ b/spec/vcs/svn_spec.rb
@@ -1,0 +1,25 @@
+require "rspec_profiling/vcs/svn"
+
+module RspecProfiling
+  describe VCS::Svn do
+    describe "#branch" do
+      it "calls Git to get the current branch" do
+        expect(subject.branch).to be_nil
+      end
+    end
+
+    describe "#sha" do
+      it "calls Git to get the current commit's SHA" do
+        expect(subject).to receive(:`).with("svn info -r 'HEAD' | grep \"Revision\" | cut -f2 -d' '").and_return("abc123")
+        expect(subject.sha).to eq "abc123"
+      end
+    end
+
+    describe "#time" do
+      it "calls Git to get the current commit's datetime" do
+        expect(subject).to receive(:`).with("svn info -r 'HEAD' | grep \"Last Changed Date\" | cut -f4,5,6 -d' '").and_return("2017-01-31")
+        expect(subject.time).to eq Time.parse("2017-01-31")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This addresses https://github.com/foraker/rspec_profiling/issues/18.

The gem will know track the branch name in addition to the already available information.

Tracking the branch name is useful when you want to track improvements made to a test suite for a particular branch over time.