### PR TITLE
Use commit_hash not commit

### DIFF
--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -5,7 +5,7 @@ module RspecProfiling
     class CSV
       HEADERS = %w{
         branch
-        commit
+        commit_hash
         date
         file
         line_number

--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -26,7 +26,7 @@ module RspecProfiling
 
         connection.create_table(table) do |t|
           t.string    :branch
-          t.string    :commit
+          t.string    :commit_hash
           t.datetime  :date
           t.text      :file
           t.integer   :line_number

--- a/lib/rspec_profiling/collectors/sql.rb
+++ b/lib/rspec_profiling/collectors/sql.rb
@@ -26,7 +26,7 @@ module RspecProfiling
 
         connection.create_table(table) do |t|
           t.string    :branch
-          t.string    :commit
+          t.string    :commit_hash
           t.datetime  :date
           t.text      :file
           t.integer   :line_number

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -28,7 +28,7 @@ module RspecProfiling
     def example_finished(*args)
       collector.insert({
         branch:        vcs.branch,
-        commit:        vcs.sha,
+        commit_hash:   vcs.sha,
         date:          vcs.time,
         file:          @current_example.file,
         line_number:   @current_example.line_number,

--- a/spec/collectors/psql_spec.rb
+++ b/spec/collectors/psql_spec.rb
@@ -14,7 +14,7 @@ module RspecProfiling
         before do
           collector.insert({
             branch: "master",
-            commit: "ABC123",
+            commit_hash: "ABC123",
             date: "Thu Dec 18 12:00:00 2012",
             file: "/some/file.rb",
             line_number: 10,
@@ -37,11 +37,11 @@ module RspecProfiling
           expect(result.branch).to eq "master"
         end
 
-        it "records the commit SHA" do
-          expect(result.commit).to eq "ABC123"
+        it "records the commit_hash SHA" do
+          expect(result.commit_hash).to eq "ABC123"
         end
 
-        it "records the commit date" do
+        it "records the commit_hash date" do
           expect(result.date).to eq Time.utc(2012, 12, 18, 12)
         end
 

--- a/spec/collectors/sql_spec.rb
+++ b/spec/collectors/sql_spec.rb
@@ -14,7 +14,7 @@ module RspecProfiling
         before do
           collector.insert({
             branch: "master",
-            commit: "ABC123",
+            commit_hash: "ABC123",
             date: "Thu Dec 18 12:00:00 2012",
             file: "/some/file.rb",
             line_number: 10,
@@ -37,11 +37,11 @@ module RspecProfiling
           expect(result.branch).to eq "master"
         end
 
-        it "records the commit SHA" do
-          expect(result.commit).to eq "ABC123"
+        it "records the commit_hash SHA" do
+          expect(result.commit_hash).to eq "ABC123"
         end
 
-        it "records the commit date" do
+        it "records the commit_hash date" do
           expect(result.date).to eq Time.utc(2012, 12, 18, 12)
         end
 

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -52,8 +52,8 @@ module RspecProfiling
         expect(result.branch).to eq "master"
       end
 
-      it "records the commit SHA" do
-        expect(result.commit).to eq "abc123"
+      it "records the commit_hash SHA" do
+        expect(result.commit_hash).to eq "abc123"
       end
 
       it "counts two queries" do


### PR DESCRIPTION
This avoids ActiveRecord::DangerousAttributeErrors due to the `commit` column clashing with internal AR methods.

This avoids errors like this in Rails 4.2.9

```
Failure/Error: raise DangerousAttributeError, "#{method_name} is defined by Active Record. Check to make sure that you don't have an attribute or method with the same name."

          ActiveRecord::DangerousAttributeError:
            commit is defined by Active Record. Check to make sure that you don't have an attribute or method with the same name.
          # /Users/jamie/projects/rspec_profiling/lib/rspec_profiling/collectors/sql.rb:50:in `insert'
          # /Users/jamie/projects/rspec_profiling/lib/rspec_profiling/run.rb:29:in `example_finished'
```

You'll need to run `rake rspec_profiling:uninstall` or change the database column from `commit` to `commit_hash`