### PR TITLE
Make CSV collector behaves like SQL collector

### DIFF
--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -32,13 +32,28 @@ module RspecProfiling
       end
 
       def initialize
-        RspecProfiling.config.csv_path ||= 'tmp/spec_benchmarks.csv'
+        RspecProfiling.config.csv_path ||= ->{ "tmp/spec_benchmark.csv" }
       end
 
       def insert(attributes)
         output << HEADERS.map do |field|
           attributes.fetch(field.to_sym)
         end
+      end
+
+      def results
+        @results ||= begin
+                       data = ::CSV.read(path)
+                       header = data.shift
+                       data.map do |row|
+                         row_in_hash = Hash[[header, row].transpose]
+                         OpenStruct.new(row_in_hash)
+                       end
+                     end
+      end
+
+      def stop
+        output.close
       end
 
       private

--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -60,6 +60,9 @@ module RspecProfiling
         end
       end
 
+      def stop
+      end
+
       private
 
       def prepared?

--- a/lib/rspec_profiling/collectors/sql.rb
+++ b/lib/rspec_profiling/collectors/sql.rb
@@ -60,6 +60,9 @@ module RspecProfiling
         end
       end
 
+      def stop
+      end
+
       private
 
       def prepared?

--- a/lib/rspec_profiling/rspec.rb
+++ b/lib/rspec_profiling/rspec.rb
@@ -1,7 +1,7 @@
 require "rspec_profiling"
 
 RSpec.configure do |config|
-  runner = RspecProfiling::Run.new(RspecProfiling.config.collector.new, 
+  runner = RspecProfiling::Run.new(RspecProfiling.config.collector.new,
                                    RspecProfiling.config.vcs.new)
 
   config.reporter.register_listener(
@@ -9,6 +9,7 @@ RSpec.configure do |config|
     :start,
     :example_started,
     :example_passed,
-    :example_failed
+    :example_failed,
+    :stop
   )
 end

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -46,6 +46,10 @@ module RspecProfiling
     alias :example_passed :example_finished
     alias :example_failed :example_finished
 
+    def stop
+      collector.stop
+    end
+
     private
 
     attr_reader :collector, :vcs

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -46,7 +46,7 @@ module RspecProfiling
     alias :example_passed :example_finished
     alias :example_failed :example_finished
 
-    def stop
+    def stop(*)
       collector.stop
     end
 

--- a/rspec_profiling.gemspec
+++ b/rspec_profiling.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sqlite3"
   spec.add_dependency "activerecord"
-  spec.add_dependency "pg"
+  spec.add_dependency "pg", '~> 0.18'
   spec.add_dependency "rails"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/spec/collectors/csv_spec.rb
+++ b/spec/collectors/csv_spec.rb
@@ -1,0 +1,94 @@
+require 'ostruct'
+require "rspec_profiling/vcs/git"
+require "rspec_profiling/collectors/sql"
+require "rspec_profiling/config"
+require "rspec_profiling/collectors/csv"
+
+module RspecProfiling
+  module Collectors
+    describe CSV do
+      before(:all) { described_class.install }
+      after(:all)  { described_class.uninstall }
+
+      describe "#insert" do
+        let(:collector) { described_class.new }
+        let(:result)    { collector.results.first }
+
+        before do
+          collector.insert({
+            branch: "master",
+            commit_hash: "ABC123",
+            date: "Thu Dec 18 12:00:00 2012",
+            file: "/some/file.rb",
+            line_number: 10,
+            description: "Some spec",
+            time: 100,
+            status: :passed,
+            exception: "some issue",
+            query_count: 10,
+            query_time: 50,
+            request_count: 1,
+            request_time: 400
+          })
+          collector.stop
+        end
+
+        it "records a single result" do
+          expect(collector.results.count).to eq 1
+        end
+
+        it "records the branch name" do
+          expect(result.branch).to eq "master"
+        end
+
+        it "records the commit_hash SHA" do
+          expect(result.commit_hash).to eq "ABC123"
+        end
+
+        it "records the commit_hash date" do
+          expect(result.date).to eq 'Thu Dec 18 12:00:00 2012'
+        end
+
+        it "records the file" do
+          expect(result.file).to eq "/some/file.rb"
+        end
+
+        it "records the line number" do
+          expect(result.line_number).to eq '10'
+        end
+
+        it "records the description" do
+          expect(result.description).to eq "Some spec"
+        end
+
+        it "records the time" do
+          expect(result.time).to eq '100'
+        end
+
+        it "records the passing status" do
+          expect(result.status).to eq 'passed'
+        end
+
+        it "records the exception" do
+          expect(result.exception). to eq 'some issue'
+        end
+
+        it "records the query count" do
+          expect(result.query_count).to eq '10'
+        end
+
+        it "records the query time" do
+          expect(result.query_time).to eq '50'
+        end
+
+        it "records the request count" do
+          expect(result.request_count).to eq '1'
+        end
+
+        it "records the request time" do
+          expect(result.request_time).to eq '400'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I use your gem to collect test statistic in csv file, it raises an error that the `spec_benchmark.csv` does not exist. 

Because the `Collectors::CSV` interface is not updated similar to `Collectors::PSQL` or `Collectors::SQL`, replacing `Collectors::CSV` in `config.collector` option will cause some commands to fail. This PR address those errors, and also add some tests to `Collectors::CSV` to ensure that it is kept up-to-date.