### PR TITLE
Strip newlines and other whitespace in Git output

### DIFF
--- a/lib/rspec_profiling/vcs/git.rb
+++ b/lib/rspec_profiling/vcs/git.rb
@@ -4,11 +4,11 @@ module RspecProfiling
   module VCS
     class Git
       def branch
-        `git rev-parse --abbrev-ref HEAD`
+        `git rev-parse --abbrev-ref HEAD`.chomp
       end
 
       def sha
-        `git rev-parse HEAD`
+        `git rev-parse HEAD`.chomp
       end
 
       def time

--- a/spec/vcs/git_spec.rb
+++ b/spec/vcs/git_spec.rb
@@ -4,22 +4,22 @@ module RspecProfiling
   describe VCS::Git do
     describe "#branch" do
       it "calls Git to get the current branch" do
-        expect(subject).to receive(:`).with("git rev-parse --abbrev-ref HEAD").and_return("master")
+        expect(subject).to receive(:`).with("git rev-parse --abbrev-ref HEAD").and_return("master\n")
         expect(subject.branch).to eq "master"
       end
     end
 
     describe "#sha" do
       it "calls Git to get the current commit's SHA" do
-        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123")
+        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123\n")
         expect(subject.sha).to eq "abc123"
       end
     end
 
     describe "#time" do
       it "calls Git to get the current commit's datetime" do
-        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123")
-        expect(subject).to receive(:`).with("git show -s --format=%ci abc123").and_return("2017-01-31")
+        expect(subject).to receive(:`).with("git rev-parse HEAD").and_return("abc123\n")
+        expect(subject).to receive(:`).with("git show -s --format=%ci abc123").and_return("2017-01-31\n")
         expect(subject.time).to eq Time.parse("2017-01-31")
       end
     end


### PR DESCRIPTION
This avoids having newlines in the CSV output.