### PR TITLE
Create indexes for DB collectors

### DIFF
--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -25,19 +25,19 @@ module RspecProfiling
         return if prepared?
 
         connection.create_table(table) do |t|
-          t.string    :branch
-          t.string    :commit_hash
-          t.datetime  :date
-          t.text      :file
-          t.integer   :line_number
+          t.string    :branch, index: true
+          t.string    :commit_hash, index: true
+          t.datetime  :date, index: true
+          t.text      :file, index: true
+          t.integer   :line_number, index: true
           t.text      :description
-          t.decimal   :time
-          t.string    :status
+          t.decimal   :time, index: true
+          t.string    :status, index: true
           t.text      :exception
-          t.integer   :query_count
-          t.decimal   :query_time
-          t.integer   :request_count
-          t.decimal   :request_time
+          t.integer   :query_count, index: true
+          t.decimal   :query_time, index:true
+          t.integer   :request_count, index: true
+          t.decimal   :request_time, index: true
           t.timestamps null: true
         end
       end

--- a/lib/rspec_profiling/collectors/sql.rb
+++ b/lib/rspec_profiling/collectors/sql.rb
@@ -25,19 +25,19 @@ module RspecProfiling
         return if prepared?
 
         connection.create_table(table) do |t|
-          t.string    :branch
-          t.string    :commit_hash
-          t.datetime  :date
-          t.text      :file
-          t.integer   :line_number
+          t.string    :branch, index: true
+          t.string    :commit_hash, index: true
+          t.datetime  :date, index: true
+          t.text      :file, index: true
+          t.integer   :line_number, index: true
           t.text      :description
-          t.decimal   :time
-          t.string    :status
+          t.decimal   :time, index: true
+          t.string    :status, index: true
           t.text      :exception
-          t.integer   :query_count
-          t.decimal   :query_time
-          t.integer   :request_count
-          t.decimal   :request_time
+          t.integer   :query_count, index: true
+          t.decimal   :query_time, index:true
+          t.integer   :request_count, index: true
+          t.decimal   :request_time, index: true
           t.timestamps null: true
         end
       end


### PR DESCRIPTION
Automatically creates index on most of columns. These are necessary for
filtering/sorting bigger amount of profiling data.

On [Gitlab](https://gitlab.com/gitlab-org/gitlab) the profiling table contains tens of millions of records (https://gitlab.com/gitlab-org/gitlab/-/issues/213649#note_369081351)